### PR TITLE
Fix custom tags & Add new kanban mode (bg-color)

### DIFF
--- a/logtools-css-productivitypack/index.js
+++ b/logtools-css-productivitypack/index.js
@@ -269,19 +269,12 @@ a.tag[data-ref="kanban"i], [data-ref="kanban-bg" i] {
       
     /* ===== bg-color ===== */
     div[data-refs-self*="kanban-bg"] > .block-children {
-		display: inline-flex;
-		position: relative;
-		overflow-x: auto;
-		overflow-y: hidden;
-		margin: 10px;
-		padding: 0px 8px 3px 8px;
-	}
-	div[data-refs-self*="kanban-bg"] >.block-children > div {
-    	display: inline-block;
-    	width: 400px;
+	padding: 0px 8px 3px 8px;
+    }
+    div[data-refs-self*="kanban-bg"] >.block-children > div {
     	border-radius: 15px;
-		background: var(--ls-secondary-background-color);
-	}
+	background: var(--ls-secondary-background-color);
+    }
 
    /* wide */
    div[data-refs-self*="kanban-wide"] > .block-children  {

--- a/logtools-css-productivitypack/index.js
+++ b/logtools-css-productivitypack/index.js
@@ -159,13 +159,11 @@ function main () {
 /* numbered lists 0.3 20210605 */
 /* usage : tag parent block with #numlist */
 
-a.tag[data-ref="🔢" i]::before,
 a.tag[data-ref="numlist" i]::before {
   content: "🔢";
   visibility: visible;
 }
 
-a.tag[data-ref="🔢" i],
 a.tag[data-ref="numlist" i] {
   visibility: hidden;
   width: 1.5em;
@@ -235,23 +233,25 @@ a.tag[data-ref="numlist" i] {
 
 
 /* css columns view for child blocks by cannibalox v20210222 */
-/* use: inline tag #kanban, #kanban-small or #kanban-wXXX    */
+/* use: inline tag #kanban, #kanban-small, #kanban-bg or #kanban-wXXX */
 /* try:  #kanban-w200,#kanban-w300, #kanban-w400             */
 
-a.tag[data-ref="🗂" i],
-a.tag[data-ref="kanban" i] {
+a.tag[data-ref="kanban" i]::before {
+  content: "🗂";
+  visibility: visible;
+}
+a.tag[data-ref="kanban-bg" i]::before {
+  content: "🗂🎨";
+  visibility: visible;
+}
+
+a.tag[data-ref="kanban"i], [data-ref="kanban-bg" i] {
   visibility: hidden;
   width: 1.5em;
   height: 1.5em;
   white-space: nowrap;
   text-shadow: var(--ct-tag-shadow);
   position: relative;
-}
-
-a.tag[data-ref="🗂" i]::before,
-a.tag[data-ref="kanban-w200" i]::before {
-  content: "🗂";
-  visibility: visible;
 }
 
    div[data-refs-self*="kanban"] > .block-children {
@@ -266,6 +266,22 @@ a.tag[data-ref="kanban-w200" i]::before {
       width: 400px;
       padding-right: 3px;
       }
+      
+    /* ===== bg-color ===== */
+    div[data-refs-self*="kanban-bg"] > .block-children {
+		display: inline-flex;
+		position: relative;
+		overflow-x: auto;
+		overflow-y: hidden;
+		margin: 10px;
+		padding: 0px 8px 3px 8px;
+	}
+	div[data-refs-self*="kanban-bg"] >.block-children > div {
+    	display: inline-block;
+    	width: 400px;
+    	border-radius: 15px;
+		background: var(--ls-secondary-background-color);
+	}
 
    /* wide */
    div[data-refs-self*="kanban-wide"] > .block-children  {


### PR DESCRIPTION
- Fix custom tags for kanban
- Add ``#kanban-bg``: Gives a background color to kanban (when using ``#kanban-bg``)
- Add a new custom tag for kanban-bg